### PR TITLE
Add JPEG rendering pipeline support

### DIFF
--- a/src/components/APIDemo.tsx
+++ b/src/components/APIDemo.tsx
@@ -395,7 +395,9 @@ print(result["image_url"])`;
                   <pre className="bg-[hsl(var(--editor-background))] p-3 rounded-md text-xs overflow-auto border">
 {`{
   "success": true,
-  "image_url": "https://...generated-image.png",
+  "image_url": "https://...generated-image.jpg",
+  "jpeg_url": "https://...generated-image.jpg",
+  "png_url": "https://...generated-image.png",
   "template_id": "template_123",
   "generation_time": "1.2s"
 }`}

--- a/src/components/ImageEditor.tsx
+++ b/src/components/ImageEditor.tsx
@@ -206,13 +206,13 @@ export const ImageEditor = ({ uploadedImage, templateData, onTemplateSaved }: Im
     if (!fabricCanvas) return;
     
     const dataURL = fabricCanvas.toDataURL({
-      format: 'png',
-      quality: 1,
+      format: 'jpeg',
+      quality: 0.9,
       multiplier: 1,
     });
-    
+
     const link = document.createElement('a');
-    link.download = 'edited-image.png';
+    link.download = 'edited-image.jpg';
     link.href = dataURL;
     link.click();
     
@@ -246,6 +246,7 @@ export const ImageEditor = ({ uploadedImage, templateData, onTemplateSaved }: Im
         .upload(filePath, blob, {
           cacheControl: '3600',
           upsert: false,
+          contentType: blob.type || undefined,
         });
 
       if (error) {
@@ -278,28 +279,30 @@ export const ImageEditor = ({ uploadedImage, templateData, onTemplateSaved }: Im
       
       // Generate thumbnail (smaller version)
       const thumbnailDataURL = fabricCanvas.toDataURL({
-        format: 'png',
+        format: 'jpeg',
         quality: 0.8,
         multiplier: 0.3
       });
 
       // Generate full edited image
       const editedImageDataURL = fabricCanvas.toDataURL({
-        format: 'png',
-        quality: 1,
+        format: 'jpeg',
+        quality: 0.9,
         multiplier: 1
       });
 
       // Prepare upload promises
       const uploadPromises = [
-        uploadImageToStorage(thumbnailDataURL, `${templateName}-thumbnail.png`),
-        uploadImageToStorage(editedImageDataURL, `${templateName}-edited.png`)
+        uploadImageToStorage(thumbnailDataURL, `${templateName}-thumbnail.jpg`),
+        uploadImageToStorage(editedImageDataURL, `${templateName}-edited.jpg`)
       ];
 
       // If original image is a data URL (from file upload), upload it too
       let originalImageStorageUrl = originalImageUrl;
       if (originalImageUrl && originalImageUrl.startsWith('data:')) {
-        uploadPromises.push(uploadImageToStorage(originalImageUrl, `${templateName}-original.png`));
+        const match = originalImageUrl.match(/^data:image\/(\w+)/i);
+        const originalExtension = match ? match[1].toLowerCase() : 'png';
+        uploadPromises.push(uploadImageToStorage(originalImageUrl, `${templateName}-original.${originalExtension}`));
       }
 
       // Upload all images

--- a/supabase/functions/api-generate/index.ts
+++ b/supabase/functions/api-generate/index.ts
@@ -165,6 +165,8 @@ serve(async (req) => {
     return new Response(JSON.stringify({
       success: true,
       image_url: renderResponse.data.image_url,
+      jpeg_url: renderResponse.data.jpeg_url ?? null,
+      png_url: renderResponse.data.png_url ?? null,
       template_id,
       generation_time: renderResponse.data.generation_time || '1.2s',
       message: 'Image generated successfully'


### PR DESCRIPTION
## Summary
- extend svg renderer edge function to produce and upload both PNG and JPEG derivatives using ImageScript
- update render pipeline and api responses to prefer JPEG download links while still exposing PNG URLs
- align editor exports and documentation to default to JPEG assets, including template thumbnails and demo output

## Testing
- npm run lint (fails: existing lint errors in repository)


------
https://chatgpt.com/codex/tasks/task_e_68cfced51ca8832e99bd982f63c67707